### PR TITLE
charm updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ juju deploy nrpe --series bionic
 juju relate docker-registry nrpe
 ```
 
+### Kubernetes Integration
+
+See the [Private Docker Registry][k8s-wiki] wiki for details on integrating
+this charm with Kubernetes.
+
+[k8s-wiki]: https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/WIP:-Private-Docker-Registry
+
 ## Actions
 
 ### Hosting Images
@@ -88,7 +95,7 @@ given `image` and subsequently tag/push it.
 
 The default image tag is 'net_loc/name:version', where 'net_loc' is the
 `http-host` config option or http[s]://[private-ip]:[port] if config is not
-set. The image tag can be overriden by specifying the `tag` action paramenter.
+set. The image tag can be overriden by specifying the `tag` action parameter.
 
 ### Starting/Stoping
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ juju deploy ~containers/easyrsa
 juju relate easyrsa docker-registry
 ```
 
+This charm also supports configuration-based TLS, which does not require a
+relation to a TLS provider. Instead, transfer required files and configure
+this charm as follows:
+
+```bash
+juju scp /my/local/ca.pem docker-registry/0:/home/ubuntu/ca.pem
+juju scp /my/local/cert.crt docker-registry/0:/home/ubuntu/cert.crt
+juju scp /my/local/cert.key docker-registry/0:/home/ubuntu/cert.key
+
+juju config docker-registry \
+  tls-ca-path=/home/ubuntu/ca.pem \
+  tls-cert-path=/home/ubuntu/cert.crt \
+  tls-key-path=/home/ubuntu/cert.key
+```
+
 ### Proxied Registry
 
 This charm supports an `http` proxy relation that allows operators to
@@ -44,10 +59,6 @@ juju relate haproxy docker-registry
 juju expose haproxy
 ```
 
-### Integration with Kubernetes
-
-See the Kubernetes private docker registry wiki for details.
-
 ### Nagios Monitoring
 
 This charm supports monitoring with nagios:
@@ -59,39 +70,54 @@ juju deploy nrpe --series bionic
 juju relate docker-registry nrpe
 ```
 
-## Hosting Images
+## Actions
 
-To make an image available in your private docker registry, you must tag and
-push it. This charm provides an action that will do this:
+### Hosting Images
+
+To make an image available in the deployed registry, it must be tagged and
+pushed. This charm provides the `push` action to do this:
 
 ```bash
-juju run-action --wait docker-registry push \
+juju run-action --wait docker-registry/0 push \
   image=<image> pull=<True|False> tag=<optional-tag-name>
 ```
 
-By default, this action will tag/push a local image so it is available from
-your registry. If you specify `pull=True`, the action will first pull the
+This action will always tag and push a local image to the registry. By
+specifying `pull=True` (the default), the action will first pull the
 given `image` and subsequently tag/push it.
 
 The default image tag is 'net_loc/name:version', where 'net_loc' is the
 `http-host` config option or http[s]://[private-ip]:[port] if config is not
 set. The image tag can be overriden by specifying the `tag` action paramenter.
 
+### Starting/Stoping
+
+The registry is configured to start automatically with the dockerd system
+service. It can also be started or stopped with charm actions as follows:
+
+```bash
+juju run-action --wait docker-registry/0 stop
+juju run-action --wait docker-registry/0 start
+```
+
 ## Configuration
 
-### Using Basic Authentication
+### Authentication
 
-Basic auth support can be enabled by setting charm configuration options:
+This charm supports basic (htpasswd) as well as token-based authentication.
+Configure either method as follows:
 
 ```bash
 juju config docker-registry \
-  auth-token-issuer=<name> \
-  auth-token-realm=<location> \
-  auth-token-root-certs=<cert-bundle> \
-  auth-token-service=<server>
-```
+  auth-basic-user='admin' \
+  auth-basic-password='redrum'
 
->Note: If any of the auth config options are set, they must all be set.
+juju config docker-registry \
+  auth-token-issuer='auth.example.com' \
+  auth-token-realm='myorg' \
+  auth-token-root-certs='$(base64 /path/to/file)' \
+  auth-token-service='myapp'
+```
 
 ### Swift Storage
 
@@ -109,3 +135,8 @@ juju config docker-registry \
 ```
 
 >Note: If any of the swift config options are set, they must all be set.
+
+## Contact
+
+The `docker-registry` charm is free and open source software created by the
+containers team at Canonical.

--- a/actions/push
+++ b/actions/push
@@ -37,9 +37,9 @@ tag = hookenv.action_get('tag')
 if not tag:
     # construct a tag
     port = charm_config.get('registry-port')
-    http_config = charm_config.get('http_config', '')
+    http_config = charm_config.get('http_config')
 
-    if http_config and not http_config == "":
+    if http_config:
         # When set, this config is our source of truth for the registry url
         tag = http_config
     else:

--- a/actions/start
+++ b/actions/start
@@ -32,3 +32,4 @@ except CalledProcessError:
     fail('Failed to start container: {}'.format(name))
 else:
     hookenv.action_set({'outcome': 'success'})
+    hookenv.status_set('active', '{} container was started.'.format(name))

--- a/actions/stop
+++ b/actions/stop
@@ -33,3 +33,4 @@ except CalledProcessError:
     fail('Failed to stop container: {}'.format(name))
 else:
     hookenv.action_set({'outcome': 'success'})
+    hookenv.status_set('blocked', '{} container was stopped.'.format(name))

--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ options:
   auth-token-root-certs:
     type: string
     default: ""
-    description: The root certificate bundle for the authentication tokens.
+    description: The root certificate bundle (base64 encoded) for the authentication tokens.
   auth-token-service:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,14 @@
 options:
+  auth-basic-password:
+    type: string
+    default: ""
+    description: |
+      Password for basic (htpasswd) authentication. Set this to something
+      other than an empty string to configure basic auth for the registry.
+  auth-basic-user:
+    type: string
+    default: "admin"
+    description: Username for basic (htpasswd) authentication.
   auth-token-issuer:
     type: string
     default: ""

--- a/layer.yaml
+++ b/layer.yaml
@@ -11,6 +11,7 @@ repo: https://github.com/CanonicalLtd/docker-registry-charm
 options:
   apt:
     packages:
+      - apache2-utils
       - python3-yaml
       - docker.io
     version_package: docker.io

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -121,7 +121,7 @@ def _configure_local_client():
     charm_config = hookenv.config()
 
     # client config depends on whether the registry is secure or insecure
-    netloc = _get_netloc()
+    netloc = get_netloc()
     if is_flag_set('charm.docker-registry.tls-enabled'):
         insecure_registry = ''
 
@@ -237,19 +237,6 @@ def _get_auth_token():
     return auth if os.path.isfile(cert_file) else None
 
 
-def _get_netloc():
-    '''Get the network location (host:port) for this registry.'''
-    charm_config = hookenv.config()
-
-    if charm_config.get('http-host'):
-        netloc = urlparse(charm_config['http-host']).netloc
-    else:
-        netloc = '{}:{}'.format(hookenv.unit_private_ip(),
-                                charm_config['registry-port'])
-
-    return netloc
-
-
 def _remove_if_exists(path):
     try:
         os.remove(path)
@@ -271,6 +258,17 @@ def _write_htpasswd(path, user, password):
                     level=hookenv.ERROR)
         return False
     return True
+
+
+def get_netloc():
+    '''Get the network location (host:port) for this registry.'''
+    charm_config = hookenv.config()
+    if charm_config.get('http-host'):
+        netloc = urlparse(charm_config['http-host']).netloc
+    else:
+        netloc = '{}:{}'.format(hookenv.unit_private_ip(),
+                                charm_config['registry-port'])
+    return netloc
 
 
 def get_tls_sans(relation_name=None):
@@ -447,7 +445,7 @@ def remove_tls():
     _remove_if_exists(tls_key)
 
     # unlink our local docker client tls data
-    client_tls_dst = '/etc/docker/certs.d/{}'.format(_get_netloc())
+    client_tls_dst = '/etc/docker/certs.d/{}'.format(get_netloc())
     if os.path.isdir(client_tls_dst):
         rmtree(client_tls_dst)
 

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import socket
 import subprocess
@@ -223,7 +224,8 @@ def _get_auth_token():
         # Only write a new cert bundle if root certs changed
         if data_changed('token_auth', root_certs):
             os.makedirs(os.path.dirname(cert_file), exist_ok=True)
-            host.write_file(cert_file, content=root_certs, perms=0o644)
+            decoded = base64.b64decode(root_certs).decode('utf8')
+            host.write_file(cert_file, content=decoded, perms=0o644)
             msg = 'Wrote new {}; token auth is available'.format(cert_file)
         else:
             msg = 'Token auth is available'

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -268,6 +268,7 @@ def get_netloc():
     our private_adddress:port.
     '''
     charm_config = hookenv.config()
+    netloc = None
     if charm_config.get('http-host'):
         netloc = urlparse(charm_config['http-host']).netloc
     else:
@@ -278,15 +279,17 @@ def get_netloc():
                 hookenv.ingress_address(rid=u.rid, unit=u.unit)
                 for u in hookenv.iter_units_for_relation_name(proxy.endpoint_name)
             ]
-            # NB: get the first addr; if you have multiple proxies, um, why?
-            # Presumably, the first will work just as well as any other.
+            # NB: get the first addr; presumably, the first will work just as
+            # well as any other.
             try:
                 netloc = proxy_addrs[0]
             except IndexError:
-                netloc = None
-        else:
-            netloc = '{}:{}'.format(hookenv.unit_private_ip(),
-                                    charm_config.get('registry-port', '5000'))
+                # If we fail here, the proxy is probably departing; fall out
+                # to the default netloc.
+                pass
+    if not netloc:
+        netloc = '{}:{}'.format(hookenv.unit_private_ip(),
+                                charm_config.get('registry-port', '5000'))
     return netloc
 
 

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -280,7 +280,10 @@ def get_netloc():
             ]
             # NB: get the first addr; if you have multiple proxies, um, why?
             # Presumably, the first will work just as well as any other.
-            netloc = proxy_addrs[0]
+            try:
+                netloc = proxy_addrs[0]
+            except IndexError:
+                netloc = None
         else:
             netloc = '{}:{}'.format(hookenv.unit_private_ip(),
                                     charm_config.get('registry-port', '5000'))

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -215,6 +215,10 @@ def remove_certs():
     clear_flag('charm.docker-registry.tls-enabled')
     layer.docker_registry.configure_registry()
     layer.docker_registry.start_registry()
+
+    # If we have clients, let them know our tls data has changed
+    if (is_flag_set('charm.docker-registry.client-configured')):
+        configure_client()
     report_status()
 
 

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -118,7 +118,7 @@ def handle_requests():
     # send config
     for request in registry.requests:
         hookenv.log('Sending config to registry client.')
-        request.set_registry_config(netloc, data)
+        request.set_registry_config(netloc, **data)
     registry.mark_completed()
 
 

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -88,9 +88,12 @@ def handle_requests():
     basic_password = charm_config.get('auth-basic-password')
     basic_user = charm_config.get('auth-basic-user')
     if basic_user and basic_password:
-        # only send if we have both parts of basic auth
+        # basic auth needs all or nothing
         data['basic_user'] = basic_user
         data['basic_password'] = basic_password
+    else:
+        data['basic_user'] = None
+        data['basic_password'] = None
 
     # tls config
     if is_flag_set('charm.docker-registry.tls-enabled'):
@@ -101,6 +104,7 @@ def handle_requests():
             data['tls_ca'] = tls_ca
     else:
         url_prefix = 'http'
+        data['tls_ca'] = None
 
     # http config
     http_config = charm_config.get('http_config')

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -74,31 +74,42 @@ def handle_requests():
     '''Set all the registry config that clients may care about.'''
     registry = endpoint_from_flag('endpoint.docker-registry.requests-pending')
     charm_config = hookenv.config()
-    port = charm_config.get('registry-port')
-    http_config = charm_config.get('http_config', '')
+
+    # auth config
+    basic_password = charm_config.get('auth-basic-password')
+    basic_user = charm_config.get('auth-basic-user')
 
     # tls config
     url_prefix = 'http'
-    tls_enabled = False
     tls_ca = None
     if is_flag_set('charm.docker-registry.tls-enabled'):
         url_prefix = 'https'
-        tls_enabled = True
         cert_provider = endpoint_from_flag('cert-provider.ca.available')
         if cert_provider:
             tls_ca = cert_provider.root_ca_cert
 
     # http config
-    if http_config and not http_config == "":
+    http_config = charm_config.get('http_config')
+    port = charm_config.get('registry-port')
+    if http_config:
         # When set, this config is our source of truth for the registry url
         registry_url = http_config
     else:
-        registry_url = '{}://{}:{}'.format(url_prefix, hookenv.unit_public_ip(), port)
+        # Construct a url with our proxy or private ip
+        website = endpoint_from_flag('website.available')
+        if website:
+            proxy_addrs = [hookenv.ingress_address(rid=u.rid, unit=u.unit)
+                           for u in hookenv.iter_units_for_relation_name(website.endpoint_name)]
+            registry_url = '{}://{}'.format(url_prefix, proxy_addrs[0])
+        else:
+            registry_url = '{}://{}:{}'.format(url_prefix, hookenv.unit_private_ip(), port)
 
+    # send config
     for request in registry.requests:
         hookenv.log('Sending {} and tls config to registry client.'.format(registry_url))
-        request.set_registry_config(registry_url=registry_url,
-                                    tls_enabled=tls_enabled,
+        request.set_registry_config(basic_password=basic_password,
+                                    basic_user=basic_user,
+                                    registry_url=registry_url,
                                     tls_ca=tls_ca)
     registry.mark_completed()
 
@@ -182,8 +193,6 @@ def remove_certs():
 def update_reverseproxy_config():
     website = endpoint_from_flag('website.available')
     port = hookenv.config().get('registry-port')
-    website.configure(port=port)
-
     services_yaml = """
 - service_name: %(app)s
   service_host: 0.0.0.0
@@ -200,8 +209,7 @@ def update_reverseproxy_config():
         'app': hookenv.application_name(),
         'unit': hookenv.local_unit().replace('/', '-'),
     }
-    for rel in website.relations:
-        rel.to_publish_raw.update({'all_services': services_yaml})
+    website.set_remote({'all_services': services_yaml})
 
 
 @when('charm.docker-registry.configured')

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -209,7 +209,8 @@ def update_reverseproxy_config():
         'app': hookenv.application_name(),
         'unit': hookenv.local_unit().replace('/', '-'),
     }
-    website.set_remote({'all_services': services_yaml})
+    website.configure(port=port)
+    website.set_remote(all_services=services_yaml)
 
 
 @when('charm.docker-registry.configured')


### PR DESCRIPTION
Quite a few issues came up with the registry when it went into the real world.

- refactor auth (both token and htpasswd) to be consistent and more maintanable
- send required relation data for both proxy and registry clients
- better status messages to indicate when the registry is up/down/sideways
- readme updates to talk about the above

These have been pushed to --beta in `~containers/docker-registry-7`