### PR TITLE
Fix exception in website-relations-joined

### DIFF
--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -248,7 +248,8 @@ def update_reverseproxy_config():
 
     # A proxy may change our netloc; if we have clients, tell them.
     netloc = layer.docker_registry.get_netloc()
-    if data_changed('proxy_netloc', netloc):
+    if (is_flag_set('charm.docker-registry.client-configured') and
+            data_changed('proxy_netloc', netloc)):
         configure_client()
 
 


### PR DESCRIPTION
If the website relation is joined when there are no docker-registry
relations then the hook panics trying to update the clients. This change
checks the clients exist before attempting to update them.