### PR TITLE
add storage-read-only config item, and honour it

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The default image tag is 'net_loc/name:version', where 'net_loc' is the
 `http-host` config option or http[s]://[private-ip]:[port] if config is not
 set. The image tag can be overriden by specifying the `tag` action parameter.
 
-### Starting/Stoping
+### Starting/Stopping
 
 The registry is configured to start automatically with the dockerd system
 service. It can also be started or stopped with charm actions as follows:
@@ -125,6 +125,23 @@ juju config docker-registry \
   auth-token-root-certs='$(base64 /path/to/file)' \
   auth-token-service='myapp'
 ```
+
+### Read-Only Mode
+
+The registry can be switched to [read-only mode][readonly] by setting
+the `storage-read-only` config item to `true`:
+
+```bash
+juju config docker-registry storage-read-only=true
+```
+
+[readonly]: https://docs.docker.com/registry/configuration/#readonly
+
+This may be useful when performing maintenance, or for providing
+unauthenticated download access to the backend registry storage (for
+example, a Swift object storage cluster) with another deployment of
+the charm alongside configured with authentication and
+`storage-read-only` at the default value.
 
 ### Swift Storage
 

--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,10 @@ options:
     type: int
     default: 5000
     description: The external port on which the docker registry listens.
+  storage-read-only:
+    type: boolean
+    default: false
+    description: Controls the storage maintenance option "readonly".  Will cause a restart.
   storage-swift-authurl:
     type: string
     default: ""

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -99,6 +99,9 @@ def configure_registry():
         storage['cache'] = {'blobdescriptor': 'inmemory'}
     registry_config['storage'] = storage
 
+    if charm_config.get('storage-read-only'):
+        storage['maintenance'] = {'readonly': {'enabled': True}}
+
     os.makedirs(os.path.dirname(registry_config_file), exist_ok=True)
     host.write_file(
         registry_config_file,


### PR DESCRIPTION
In order to solve https://launchpad.net/bugs/1808357 in our registry deployment, we need to be able to run a read-only instance of the registry. This branch adds a new storage-read-only config item which manipulates the "readonly" knob (https://docs.docker.com/registry/configuration/#readonly)