### PR TITLE
set "relativeurls" to true in the registry config

### DIFF
--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -42,7 +42,8 @@ def configure_registry():
     # http (https://docs.docker.com/registry/configuration/#http)
     port = charm_config.get('registry-port')
     http = {'addr': '0.0.0.0:{}'.format(port),
-            'headers': {'X-Content-Type-Options': ['nosniff']}}
+            'headers': {'X-Content-Type-Options': ['nosniff']},
+            'relativeurls': 'true'}
     if charm_config.get('http-host'):
         http['host'] = charm_config['http-host']
     http_secret = leader_get('http-secret')


### PR DESCRIPTION
This allows your registry to work correctly if you're making the TLS
termination on a frontend. Not compatible with docker 1.7 and earlier.