### PR TITLE
 update for multiple frontend proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ juju add-relation haproxy docker-registry
 ```
 
 When multiple `docker-registry` units are deployed, the proxy will be
-configured using the network information of the registry leader. This provides
-a highly available deployment that will fail over to a newly elected leader
-if the original leader becomes unavailable.
+configured with one unit chosen as the primary proxied service with remaining
+units configured as backups. This provides a highly available deployment that
+will fail over to a backup if the primary service becomes unavailable.
 
->Note: With multiple registry units deployed, the proxy relation allows for a
-highly available deployment. Load balancing across multiple registry units is
-not supported.
+>Note: HA deployments require the proxy to be in `active-passive` peering
+mode, which is the default for `haproxy`.
 
 ### Nagios Monitoring
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -7,6 +7,7 @@ includes:
 - layer:docker
 - interface:docker-registry
 - interface:http
+- interface:peer-discovery
 - interface:tls-certificates
 repo: https://github.com/CanonicalLtd/docker-registry-charm
 options:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,3 +18,6 @@ provides:
 requires:
   cert-provider:
     interface: tls-certificates
+peers:
+  peer:
+    interface: peer-discovery


### PR DESCRIPTION
https://bugs.launchpad.net/layer-docker-registry/+bug/1815459

- send proxy data for all registry units (not just leader)
- ensure oldest peer is primary backend; others are backups
- fix issues in the proxy stanza
  - s/all_services/services
    - `all_services` should only be used when fronting haproxy itself by something like the apache2 rev proxy
  - add health check params

Available in the beta channel at `cs:~containers/docker-registry-81`.