### PR TITLE
clear invalid all_services key from proxy relation

### DIFF
--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -292,6 +292,7 @@ def update_reverseproxy_config():
         website.set_remote(all_services=None)
         set_flag('charm.docker-registry.proxy-data.validated')
 
+
 @when('charm.docker-registry.configured')
 @when('nrpe-external-master.available')
 def setup_nagios():

--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -286,6 +286,11 @@ def update_reverseproxy_config():
             data_changed('proxy_netloc', netloc)):
         configure_client()
 
+    # Early versions of this charm incorrectly set an 'all_services'
+    # key on the relation. Kill it.
+    if not is_flag_set('charm.docker-registry.proxy-data.validated'):
+        website.set_remote(all_services=None)
+        set_flag('charm.docker-registry.proxy-data.validated')
 
 @when('charm.docker-registry.configured')
 @when('nrpe-external-master.available')


### PR DESCRIPTION
Prior to revision 80(ish), this charm was setting the `all_services` key on the haproxy relation.  This should have been `services`.  Fix this for people that upgrade to post rev 80(ish) by explicitly nullifying this invalid key in the proxy handler.
