### PR TITLE
New actions to list and remove images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Introduction
 
-This charm provides storage and distribution of docker images. See
-https://docs.docker.com/registry/ for details.
+This charm provides a registry for storage and distribution of docker images.
+See https://docs.docker.com/registry/ for details.
 
 ## Deployment
 
@@ -105,7 +105,7 @@ integrating this charm with Kubernetes.
 
 ## Actions
 
-### Hosting Images
+### Adding Images
 
 To make an image available in the deployed registry, it must be tagged and
 pushed. This charm provides the `push` action to do this:
@@ -122,6 +122,43 @@ given `image` and subsequently tag/push it.
 The default image tag is 'net_loc/name:version', where 'net_loc' is the
 `http-host` config option or http[s]://[private-ip]:[port] if config is not
 set. The image tag can be overriden by specifying the `tag` action parameter.
+
+### Listing Images
+
+List images known to the registry with the `images` action:
+
+```bash
+juju run-action --wait docker-registry/0 images \
+  options=<extra-args> repository=<repository[:tag]>
+```
+
+This runs `docker images` on the registry machine. The optional `options` and
+`repository` parameters are passed through to the underlying command. For
+example, show non-truncated output with numeric image IDs:
+
+```bash
+juju run-action --wait docker-registry/0 images \
+  options="--no-trunc --quiet"
+```
+
+### Removing Images
+
+Remove images from the registry with the `rmi` action:
+
+```bash
+juju run-action --wait docker-registry/0 rmi \
+  options=<extra-args> image=<image [image...]>
+```
+
+This runs `docker rmi` on the registry machine. The image name (or space
+separated names) must be specified using the `image` parameter. The optional
+`options` parameter is passed through to the underlying command. For
+example, remove the ubuntu:18.04 image without deleting untagged parents:
+
+```bash
+juju run-action --wait docker-registry/0 rmi \
+  options="--no-prune" image="ubuntu:18.04"
+```
 
 ### Starting/Stopping
 

--- a/actions.yaml
+++ b/actions.yaml
@@ -55,7 +55,8 @@ rmi:
       type: string
       default: ''
       description: |
-        Image name (or space separated names) to remove.
+        Image (or space separated images) to remove. This can be be an image
+        id, tag, or digest.
   required: [image]
   additionalProperties: false
 start:

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,6 +1,24 @@
+images:
+  description: |
+    List images known by this registry.
+  params:
+    options:
+      type: string
+      default: ''
+      description: |
+        Space separated options to pass to the underlying 'docker images'
+        command. For example, to list all images (including intermediates)
+        along with digests, run this action with 'options="--all --digests"'.
+    repository:
+      type: string
+      default: ''
+      description: |
+        Optional [REPOSITORY[:TAG]] to list images in a given repository. If
+        unspecified, all images known to the registry are listed.
+  additionalProperties: false
 push:
   description: |
-    Tag and push an image to this repository.
+    Tag and push an image to this registry.
   params:
     image:
       type: string
@@ -8,8 +26,8 @@ push:
       description: |
         Image name, which may include an optional :version string. If the
         version is omitted, docker will assume ':latest'. This may be an
-        unqualified local image (e.g. pause-amd64:3.1) or a fully qualified
-        remote URL (e.g. https://k8s.gcr.io/pause-amd64:3.1).
+        unqualified local image (e.g. ubuntu:18.04) or a fully qualified
+        remote registry (e.g. myregistry.example.com:5000/myimage:latest).
     pull:
       type: boolean
       default: true
@@ -22,30 +40,46 @@ push:
         'net_location/name:version'.
   required: [image]
   additionalProperties: false
+rmi:
+  description: |
+    Remove image(s) from this registry.
+  params:
+    options:
+      type: string
+      default: ''
+      description: |
+        Space separated options to pass to the underlying 'docker rmi'
+        command. For example, to force image removal, run this action with
+        'options="--force"'.
+    image:
+      type: string
+      default: ''
+      description: |
+        Image name (or space separated names) to remove.
+  required: [image]
+  additionalProperties: false
 start:
   description: |
-    Start a named docker container.
+    Start a named registry container. With no arguments, this action starts
+    the registry container configured by the charm 'registry-name' option.
   params:
     name:
       type: string
       default: ''
-      description: |
-        Name of the container to start. If not specified, the action will
-        attempt to start the configured 'registry-name' container.
+      description: Optional name of the registry container to start.
   additionalProperties: false
 stop:
   description: |
-    Stop a named docker container.
+    Stop a named registry container. With no arguments, this action stops
+    the registry container configured by the charm 'registry-name' option.
   params:
     name:
       type: string
       default: ''
-      description: |
-        Name of the container to stop. If not specified, the action will
-        attempt to stop the configured 'registry-name' container.
+      description: Optional name of the registry container to stop.
     remove:
       type: boolean
       default: true
       description: |
-        Remove the named container after stopping.
+        Remove the registry container after stopping.
   additionalProperties: false

--- a/actions/images
+++ b/actions/images
@@ -1,6 +1,7 @@
 #!/usr/local/sbin/charm-env python3
 
 import sys
+from shlex import split
 from subprocess import check_output, CalledProcessError, STDOUT
 
 from charmhelpers.core import hookenv
@@ -24,7 +25,7 @@ if not is_flag_set('charm.docker-registry.configured'):
 cmd = ['docker', 'images']
 options = hookenv.action_get('options')
 if options:
-    cmd.extend(options.split())
+    cmd.extend(split(options))
 repo = hookenv.action_get('repository')
 if repo:
     cmd.append(repo)
@@ -32,7 +33,7 @@ if repo:
 try:
     r = check_output(cmd, stderr=STDOUT).decode('utf-8')
 except CalledProcessError as e:
-    fail("{} failed with: {}".format(e.cmd, e.output.decode('utf-8')))
+    fail('"{}" failed with:\n{}'.format(
+        ' '.join(e.cmd), e.output.decode('utf-8')))
 else:
-    hookenv.action_set({'outcome': 'success'})
     hookenv.action_set({'output': r})

--- a/actions/images
+++ b/actions/images
@@ -1,0 +1,38 @@
+#!/usr/local/sbin/charm-env python3
+
+import sys
+from subprocess import check_output, CalledProcessError, STDOUT
+
+from charmhelpers.core import hookenv
+from charms import layer
+from charms.reactive import is_flag_set
+
+layer.import_layer_libs()
+
+# start reactive
+hookenv._run_atstart()
+
+
+def fail(msg):
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+if not is_flag_set('charm.docker-registry.configured'):
+    fail('Docker Registry charm is not yet ready.')
+
+cmd = ['docker', 'images']
+options = hookenv.action_get('options')
+if options:
+    cmd.extend(options.split())
+repo = hookenv.action_get('repository')
+if repo:
+    cmd.append(repo)
+
+try:
+    r = check_output(cmd, stderr=STDOUT).decode('utf-8')
+except CalledProcessError as e:
+    fail("{} failed with: {}".format(e.cmd, e.output.decode('utf-8')))
+else:
+    hookenv.action_set({'outcome': 'success'})
+    hookenv.action_set({'output': r})

--- a/actions/rmi
+++ b/actions/rmi
@@ -1,0 +1,40 @@
+#!/usr/local/sbin/charm-env python3
+
+import sys
+from subprocess import check_output, CalledProcessError, STDOUT
+
+from charmhelpers.core import hookenv
+from charms import layer
+from charms.reactive import is_flag_set
+
+layer.import_layer_libs()
+
+# start reactive
+hookenv._run_atstart()
+
+
+def fail(msg):
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+if not is_flag_set('charm.docker-registry.configured'):
+    fail('Docker Registry charm is not yet ready.')
+
+cmd = ['docker', 'rmi']
+options = hookenv.action_get('options')
+if options:
+    cmd.extend(options.split())
+image = hookenv.action_get('image')
+if image:
+    cmd.extend(image.split())
+else:
+    fail('No image name(s) specified.')
+
+try:
+    r = check_output(cmd, stderr=STDOUT).decode('utf-8')
+except CalledProcessError as e:
+    fail("{} failed with: {}".format(e.cmd, e.output.decode('utf-8')))
+else:
+    hookenv.action_set({'outcome': 'success'})
+    hookenv.action_set({'output': r})

--- a/actions/rmi
+++ b/actions/rmi
@@ -1,6 +1,7 @@
 #!/usr/local/sbin/charm-env python3
 
 import sys
+from shlex import split
 from subprocess import check_output, CalledProcessError, STDOUT
 
 from charmhelpers.core import hookenv
@@ -24,17 +25,17 @@ if not is_flag_set('charm.docker-registry.configured'):
 cmd = ['docker', 'rmi']
 options = hookenv.action_get('options')
 if options:
-    cmd.extend(options.split())
+    cmd.extend(split(options))
 image = hookenv.action_get('image')
 if image:
-    cmd.extend(image.split())
+    cmd.extend(split(image))
 else:
     fail('No image name(s) specified.')
 
 try:
     r = check_output(cmd, stderr=STDOUT).decode('utf-8')
 except CalledProcessError as e:
-    fail("{} failed with: {}".format(e.cmd, e.output.decode('utf-8')))
+    fail('"{}" failed with:\n{}'.format(
+        ' '.join(e.cmd), e.output.decode('utf-8')))
 else:
-    hookenv.action_set({'outcome': 'success'})
     hookenv.action_set({'output': r})


### PR DESCRIPTION
- Address https://bugs.launchpad.net/layer-docker-registry/+bug/1808200 with an action that lets operators remove registry images.  This is effectively a wrapper around `docker rmi`.
- Let the people list images while we're at it.  This is effectively `docker images`.

These actions have been released in charm rev 125, currently in the beta channel:
https://jujucharms.com/u/containers/docker-registry/125
