### PR TITLE
config to delete by digest; host volume to persist local images

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,16 +189,29 @@ juju config docker-registry \
   auth-token-service='myapp'
 ```
 
+### Delete by digest
+
+The recommended way to delete images from the reigstry is to use the `rmi`
+action. If necessary, this charm can be configured to
+[allow deletion][storage-delete] of blobs and manifests by digest by setting
+the `storage-delete` config option to `true`:
+
+```bash
+juju config docker-registry storage-delete=true
+```
+
+[storage-delete]: https://docs.docker.com/registry/configuration/#delete
+
 ### Read-Only Mode
 
-The registry can be switched to [read-only mode][readonly] by setting
+The registry can be switched to [read-only mode][storage-readonly] by setting
 the `storage-read-only` config option to `true`:
 
 ```bash
 juju config docker-registry storage-read-only=true
 ```
 
-[readonly]: https://docs.docker.com/registry/configuration/#readonly
+[storage-readonly]: https://docs.docker.com/registry/configuration/#readonly
 
 This may be useful when performing maintenance or deploying an environment
 with complex authentication requirements.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ juju config docker-registry \
 
 ### Delete by digest
 
-The recommended way to delete images from the reigstry is to use the `rmi`
+The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
 [allow deletion][storage-delete] of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:

--- a/config.yaml
+++ b/config.yaml
@@ -51,10 +51,18 @@ options:
     type: int
     default: 5000
     description: The external port on which the docker registry listens.
+  storage-delete:
+    type: boolean
+    default: false
+    description: |
+      Enable/disable the "delete" storage option. False, the default, disables
+      this option in the registry config file.
   storage-read-only:
     type: boolean
     default: false
-    description: Controls the storage maintenance option "readonly".
+    description: |
+      Enable/disable the "readonly" storage maintenance option. False, the
+      default, disables this option in the registry config file.
   storage-swift-authurl:
     type: string
     default: ""


### PR DESCRIPTION
Couple storage-related updates:

- Expose "delete by digest" config capabilities.  This enables deletion of blobs and manifests via the rest api like:
```
curl -u "user:pass" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
  -X DELETE https://<registryurl>:5000/v2/busybox/manifests/<sha256 hash>
```
- Persist local images. When using local storage, images live in the registry container's /var/lib/registry. Ensure this is a volume mount from the host so images persist across registry restarts.