### PR TITLE
lp:1828532 scrub proxy relation data for all peers

### DIFF
--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -294,6 +294,19 @@ def update_reverseproxy_config():
 
 
 @when('charm.docker-registry.configured')
+@when('website.available')
+@when_not('leadership.is_leader')
+def validate_follower_reverseproxy():
+    '''Remove invalid reverseproxy config for non-leader units.'''
+    # Early versions of this charm (rev 80ish) incorrectly set website config
+    # for follower units. Clean that up.
+    website = endpoint_from_flag('website.available')
+    if not is_flag_set('charm.docker-registry.proxy-data.validated'):
+        website.set_remote(all_services=None, hostname=None, port=None)
+        set_flag('charm.docker-registry.proxy-data.validated')
+
+
+@when('charm.docker-registry.configured')
 @when('leadership.is_leader')
 @when('endpoint.website.departed')
 def remove_reverseproxy_config():


### PR DESCRIPTION
See https://bugs.launchpad.net/layer-docker-registry/+bug/1828532

Way back in the 60s (revision 60s, that is), we added some invalid config on the website relation for both leader and follower units.  In the 80s (rev 87, #26), we corrected this with valid config, and in the early 100s (rev 101, #28), we sanitized the website relation data. Unfortunately, as the above bug shows, this only cleaned up the invalid config on leader units.

This PR does a similar cleanup for non-leader units.