### PR TITLE
stub out docker-compose charm-pre-install

### DIFF
--- a/exec.d/docker-compose/charm-pre-install
+++ b/exec.d/docker-compose/charm-pre-install
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# This stubs out charm-pre-install coming from layer-docker as a workaround for
+# offline installs until https://github.com/juju/charm-tools/issues/301 is fixed.


### PR DESCRIPTION
The pre-install script from [layer-docker](https://github.com/juju-solutions/layer-docker/blob/master/exec.d/docker-compose/charm-pre-install) installs things from pip, which doesn't work in offline environments. Since the registry doesn't need docker-compose, just stub it out so we can deploy this charm in offline environments.