### PR TITLE
Make sure htpasswd is available before configuring the registry

### DIFF
--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -17,7 +17,8 @@ from charms.leadership import leader_set
 from charms.reactive.helpers import data_changed
 
 
-@when('docker.ready')
+@when('docker.ready',
+      'apt.installed.apache2-utils')
 @when_not('charm.docker-registry.configured')
 def start():
     layer.status.maint('Configuring the registry.')


### PR DESCRIPTION
The command is required to create /etc/docker/registry/htpasswd when
basic authentication is chosen.

[LP: #1829529](https://bugs.launchpad.net/layer-docker-registry/+bug/1829529)