### PR TITLE
Change permissions on config.yml

### DIFF
--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -121,7 +121,7 @@ def configure_registry():
     host.write_file(
         registry_config_file,
         yaml.safe_dump(registry_config),
-        perms=0o644,
+        perms=0o600,
     )
 
     # NB: all hooks will flush, but do an explicit one now in case we call


### PR DESCRIPTION
Changed charm to write config.yml with 600 permissions.

Fixes: [#1832639](https://bugs.launchpad.net/layer-docker-registry/+bug/1832639)

LP:#1832639