### PR TITLE
Stop writing daemon.json directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.tox/
+__pycache__/
+*.pyc
 .*.swp
 dist/
 builds/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.5"
+install:
+  - pip install tox-travis
+script:
+  - tox

--- a/layer.yaml
+++ b/layer.yaml
@@ -15,3 +15,6 @@ options:
     packages:
       - apache2-utils
       - python3-yaml
+exclude:
+  - .tox
+  - __pycache__

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from shutil import rmtree
 from urllib.parse import urlparse
 
-from charmhelpers.core import hookenv, host, templating, unitdata
+from charmhelpers.core import hookenv, host, unitdata
 from charms.layer import docker
 from charms.leadership import leader_get
 from charms.reactive import endpoint_from_flag, is_flag_set
@@ -37,7 +37,8 @@ def configure_registry():
     auth_token = _get_auth_token()
     if auth_token:
         auth['token'] = auth_token
-        docker_volumes[auth_token['rootcertbundle']] = '/etc/docker/registry/auth_token.pem'
+        docker_volumes[auth_token['rootcertbundle']] = \
+            '/etc/docker/registry/auth_token.pem'
     registry_config['auth'] = auth
 
     # http (https://docs.docker.com/registry/configuration/#http)
@@ -101,9 +102,10 @@ def configure_registry():
             'tenant': charm_config.get('storage-swift-tenant', ''),
         }
 
-        # Openstack Domain settings (https://github.com/docker/docker.github.io/blob/master/registry/storage-drivers/swift.md)
+        # Openstack Domain settings
+        # (https://docs.docker.com/registry/storage-drivers/swift/)
         val = charm_config.get('storage-swift-domain', '')
-        if val is not '':
+        if val != '':
             storage['swift'].update({'domain': val})
 
         storage['redirect'] = {'disable': True}
@@ -419,9 +421,10 @@ def start_registry(name=None, run_args=None):
                         level=hookenv.ERROR)
             raise
     else:
-        # NB: config determines the port, but the container always listens to 5000 internally
+        # NB: config determines the port, but the container always listens to 5000
         # https://docs.docker.com/registry/deploying/#customize-the-published-port
-        cmd = ['docker', 'run', '-d', '-p', '{}:5000'.format(port), '--restart', 'unless-stopped']
+        cmd = ['docker', 'run', '-d', '-p', '{}:5000'.format(port),
+               '--restart', 'unless-stopped']
         if run_args:
             cmd.extend(run_args)
         # Add our docker volume mounts

--- a/templates/daemon.json
+++ b/templates/daemon.json
@@ -1,3 +1,0 @@
-{
-  "insecure-registries" : [ {{ registries }} ]
-}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+# mock dependencies which we don't care about covering in our tests
+ch = MagicMock()
+sys.modules['charmhelpers'] = ch
+sys.modules['charmhelpers.contrib'] = ch.contrib
+sys.modules['charmhelpers.contrib.hahelpers'] = ch.contrib.hahelpers
+sys.modules['charmhelpers.contrib.hahelpers.cluster'] = ch.contrib.hahelpers.cluster
+sys.modules['charmhelpers.core'] = ch.core
+charms = MagicMock()
+sys.modules['charms'] = charms
+sys.modules['charms.layer'] = charms.layer
+sys.modules['charms.leadership'] = charms.leadership
+sys.modules['charms.reactive'] = charms.reactive
+sys.modules['charms.reactive.helpers'] = charms.reactive.helpers
+
+os.environ['JUJU_MODEL_UUID'] = 'test-1234'

--- a/tests/test_docker_registry.py
+++ b/tests/test_docker_registry.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest import mock
+
+
+def patch_fixture(patch_target):
+    @pytest.fixture()
+    def _fixture():
+        with mock.patch(patch_target) as m:
+            yield m
+    return _fixture
+
+
+def test_imports():
+    # dummy test to just make sure files import properly
+    # replace with real tests later
+    from reactive import docker_registry as handlers
+    assert handlers

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pytest
+    flake8
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 --max-line-length=88 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests


### PR DESCRIPTION
Refactor to update daemon.json through the docker layer api rather
than writing the file directly.

Depends on https://github.com/juju-solutions/layer-docker/pull/141

Testing steps followed:
```
juju deploy cs:~containers/docker-registry
juju config docker-registry \
  auth-basic-user='admin' \
  auth-basic-password='password'
```
Confirmed registry came up and I could login.
```
juju run --unit docker-registry/0 "docker login -u admin -p password 172.31.71.92:5000"
```
Upgraded to the new charm.
```
juju upgrade-charm docker-registry --switch /tmp/charm-builds/docker-registry
```
Confirmed I could still login, and `/etc/docker/daemon.json` contained the json from the `daemon-opts` charm config, with the `insecure-registries` key added in by the charm.
```
juju run -a docker-registry "cat /etc/docker/daemon.json"
- Stdout: '{"insecure-registries": ["172.31.71.92:5000"], "log-driver":
    "json-file", "log-opts": {"max-size": "10m", "max-file": "100"}}'
  UnitId: docker-registry/0
```
Added a new key/val to `daemon-opts` ("debug": true).
```
juju run -a docker-registry "cat /etc/docker/daemon.json"
- Stdout: '{"insecure-registries": ["172.31.71.92:5000"], "debug": true, "log-driver":
    "json-file", "log-opts": {"max-size": "10m", "max-file": "100"}}'
  UnitId: docker-registry/0
```
Related the docker-registry charm to easyrsa to enable TLS mode. Confirmed that I could still log in, and that the "insecure-registries" entry had been removed from daemon.json.
```
juju add-relation docker-registry easyrsa:client
juju run -a docker-registry "cat /etc/docker/daemon.json"
- Stdout: '{"debug": true, "log-driver": "json-file", "log-opts": {"max-size": "10m",
    "max-file": "100"}}'
  UnitId: docker-registry/0
```
Fixes: https://bugs.launchpad.net/layer-docker-registry/+bug/1844602