### PR TITLE
Add support for series upgrade

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,22 @@
+name: Run tests with Tox
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - "3.5"
-install:
-  - pip install tox-travis
-script:
-  - tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,4 @@
-import os
-import sys
-from unittest.mock import MagicMock
+import charms.unit_test
 
-# mock dependencies which we don't care about covering in our tests
-ch = MagicMock()
-sys.modules['charmhelpers'] = ch
-sys.modules['charmhelpers.contrib'] = ch.contrib
-sys.modules['charmhelpers.contrib.hahelpers'] = ch.contrib.hahelpers
-sys.modules['charmhelpers.contrib.hahelpers.cluster'] = ch.contrib.hahelpers.cluster
-sys.modules['charmhelpers.core'] = ch.core
-charms = MagicMock()
-sys.modules['charms'] = charms
-sys.modules['charms.layer'] = charms.layer
-sys.modules['charms.leadership'] = charms.leadership
-sys.modules['charms.reactive'] = charms.reactive
-sys.modules['charms.reactive.helpers'] = charms.reactive.helpers
-
-os.environ['JUJU_MODEL_UUID'] = 'test-1234'
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('charms.leadership')

--- a/tests/test_docker_registry.py
+++ b/tests/test_docker_registry.py
@@ -1,15 +1,3 @@
-import pytest
-from unittest import mock
-
-
-def patch_fixture(patch_target):
-    @pytest.fixture()
-    def _fixture():
-        with mock.patch(patch_target) as m:
-            yield m
-    return _fixture
-
-
 def test_imports():
     # dummy test to just make sure files import properly
     # replace with real tests later

--- a/tests/test_docker_registry.py
+++ b/tests/test_docker_registry.py
@@ -1,5 +1,30 @@
-def test_imports():
-    # dummy test to just make sure files import properly
-    # replace with real tests later
-    from reactive import docker_registry as handlers
-    assert handlers
+from charms.unit_test import patch_fixture
+
+from charmhelpers.core import host  # patched
+from charms import layer
+
+from reactive import docker_registry as handlers
+
+
+start_registry = patch_fixture('charms.layer.docker_registry.start_registry')
+stop_registry = patch_fixture('charms.layer.docker_registry.stop_registry')
+
+
+def test_series_upgrade(start_registry, stop_registry):
+    assert start_registry.call_count == 0
+    assert stop_registry.call_count == 0
+    assert host.service_pause.call_count == 0
+    assert host.service_resume.call_count == 0
+    assert layer.status.blocked.call_count == 0
+    handlers.pre_series_upgrade()
+    assert start_registry.call_count == 0
+    assert stop_registry.call_count == 1
+    assert host.service_pause.call_count == 1
+    assert host.service_resume.call_count == 0
+    assert layer.status.blocked.call_count == 1
+    handlers.post_series_upgrade()
+    assert start_registry.call_count == 1
+    assert stop_registry.call_count == 1
+    assert host.service_pause.call_count == 1
+    assert host.service_resume.call_count == 1
+    assert layer.status.blocked.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv =
 deps =
     pytest
     flake8
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands = pytest --tb native -s {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
Stop the registry and put the charm into a blocked status during the series upgrade.

Part of https://bugs.launchpad.net/layer-docker-registry/+bug/1869944